### PR TITLE
Edição no texto da carta: precisão conceitual

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # TI com Boulos
 
-Em poucos momentos da história brasileira tivemos uma conjuntura como essa, onde ainda precisamos reafirmar a ciência, enfrentar notícias falsas, arregaçar as mangas para obter dados e até mesmo se precisa reforçar que a terra NÃO É PLANA.
+Em poucos momentos da história brasileira tivemos uma conjuntura como essa, na qual coisas aparentemente básicas como reafirmar ciência frente a desinformação ainda parece ser um grande desafio. Em pleno século XXI precisamos, ainda, arregaçar as mangas para obter dados que a própria Lei de Acesso à Informação nos garantiria acesso, e até mesmo reforçar que a terra NÃO É PLANA.
 
-A ignorância avança como um doença contagiosa no Brasil, sob uma falsa pauta de valores da família, que disfarça lgbtfobia, racismo, machismo, fascismo e preconceito de classe. Essa força política cresce no Brasil como uma erva daninha, sufocando todo esforço democrático já construído sob duras penas no Brasil.
+O discurso de ódio avança como um doença contagiosa no Brasil, sob uma falsa pauta de valores da família, que disfarça LGBTQ+fobia, racismo, machismo, fascismo e preconceito com relação a classe trabalhadora. Essa força política cresce no Brasil como uma erva daninha, sufocando todo esforço democrático já construído sob duras penas no Brasil.
 
-No grave momento que vivemos, precisamos resistir, precisamos nos posicionar, e não apenas como indivíduos. Precisamos nos organizar enquanto classe de TRABALHADORES E TRABALHADORAS de TI. Precisamos colocar a cara e mostrar que juntos somos mais fortes.
+No grave momento que vivemos, precisamos resistir, precisamos nos posicionar, e não apenas como indivíduos. Precisamos nos organizar enquanto classe de pessoas que trabalham em TI. Precisamos colocar a cara e mostrar que juntos somos mais fortes.
 
-Entendemos que a eleição está longe de ser a solução para o problema. Que somente com muita luta popular poderemos fazer as mudanças necessárias para que possamos ter um Brasil de fato para o povo e somente na rua podemos conquistar isso, mas as eleições existem, as pessoas são eleitas e elas governam os meios institucionais. 
+Entendemos que a eleição está longe de ser a solução para o problema. Que somente com muita luta popular poderemos fazer as mudanças necessárias para que possamos ter um Brasil de fato para o povo e somente trabalho de base podemos conquistar isso. Mas as eleições existem, as pessoas são eleitas e elas governam os meios institucionais.
 
-Exemplos anteriores de candidaturas realmente de esquerdas nos fazem ter esperança que ao votar em pessoas que tenham claro compromisso nessa resistência, inclusive conscientes que a via institucional não é a solução para todos os problemas.
+Exemplos anteriores de candidaturas de esquerdas nos fazem ter esperança em votar em pessoas que tenham claro compromisso com essa resistência,= — inclusive conscientes que a via institucional não é a solução para todos os problemas.
 
-Com isso em mente, o grupo de profissionais de TI que assinam esse documento entendem que as eleições da cidade de São Paulo em 2020 podem representar uma REAL resistência a essas posturas e posicionamentos no Brasil e a candidatura Boulos e Erundina 50 apresenta as propostas mais consistentes com o enfrentamento à grave crise que atravessamos. As propostas apresentadas trazem a construção dos instrumentos de política econômica e social necessários para reerguer a economia local e reduzir os efeitos da elevada miséria e desemprego.
+Com isso em mente, o grupo de profissionais de TI que assina esse documento entende que as eleições da cidade de São Paulo em 2020 podem representar uma REAL resistência a essas posturas e posicionamentos no Brasil, e a candidatura Boulos e Erundina 50 apresenta as propostas mais consistentes com o enfrentamento à grave essa crise político-democrática que atravessamos.
+
+As propostas apresentadas trazem a construção dos instrumentos de política econômica e social necessários para reerguer a economia local e reduzir os efeitos da elevada miséria e desemprego. O histórico de ambas as pessoa que compõe a chapa nos passa segurança de que, uma vez eleitas, caso as propostas não sejam viáveis, haverá espaço para participação popular e democrática na construção de alternativas.
+
+E, por fim, acreditamos que passamos uma mensagem de esperança em meio a tantos governos com base em ódio, desinformação e necropolítica: Boulos e Erundina respeitam e defendem o direitos humanos e as instituições que são pilares das democracias modernas.
 
  - Rafael Gomes  Engenheiro DevOps
  - Fernando Freitas Júnior  Desenvolvedor
@@ -37,5 +41,3 @@ Faça um fork desse projeto, coloque seu nome abaixo do ultimo nome, coloque seu
 ## Vira SP com Boulos e Erundina
 
 - [Site oficial da Campanha](https://virasp.com.br/)
-
-


### PR DESCRIPTION
Esse commit sugere edições no texto da carta para dar precisão conceitual em termos citados vagamente na versão atual. Por exemplo:

- usando termos mais específicos como _desinformação_ e _discurso de ódio_ ao invés de _notícias falsas_
- evitando a uso acrítico de _ignorância_ 
- conferindo maior precisão em passagens específicas como _dados da LAI_ ao invés de só _dados_, ou _preconceito contra a classe trabalhadora_ ao invés de _preconceito de classe_
- evitando expressões vagas como _realmente de esquerda_
- sugerindo mais motivos para apoiar a chapa

Minha ideia não é mudar a estrutura da carta, mas apenas deixá-la mais precisa. Isso é subjetivo e entendo que talvez precise de mais discussão. E entendo que talvez quem já tenha assinado pode não concordar em manter a assinatura depois dessas edições.